### PR TITLE
issue #8 - [self dismissAlertView] inside handleButtonTouched:

### DIFF
--- a/AMSmoothAlertViewDemo/AMSmoothAlert/AMSmoothAlertView.m
+++ b/AMSmoothAlertViewDemo/AMSmoothAlert/AMSmoothAlertView.m
@@ -442,14 +442,13 @@
 
 #pragma mark - Delegate Methods
 - (void)handleButtonTouched:(id)sender {
+	[self dismissAlertView];
+
 	id<AMSmoothAlertViewDelegate> delegate = self.delegate;
 	UIButton *button = (UIButton *) sender;
 	if ([delegate respondsToSelector:@selector(alertView:didDismissWithButton:)]) {
 		// Since there isn't a button index for the alertView, pass the button
 		[delegate alertView:self didDismissWithButton:button];
-	}
-	else {
-		[button addTarget:self action:@selector(dismissAlertView) forControlEvents:UIControlEventTouchUpInside];
 	}
 }
 


### PR DESCRIPTION
I was doing `addTarget` for dismissing the alertView rather than dismissing the alertView, haha. We can add more functionality and refactor it to be much cleaner going forward
