### PR TITLE
#8 - Add delegates for alertViewWillShow, alertViewDidShow, alertViewWil...

### DIFF
--- a/AMSmoothAlertViewDemo/AMSmoothAlert/AMSmoothAlertView.h
+++ b/AMSmoothAlertViewDemo/AMSmoothAlert/AMSmoothAlertView.h
@@ -46,9 +46,9 @@
 
 @optional
 -(void) alertView:(AMSmoothAlertView *)alertView didDismissWithButton:(UIButton *)button;
--(void) alertViewWillShow;
--(void) alertViewDidShow;
--(void) alertViewWillDismiss;
--(void) alertViewDidDismiss;
+-(void) alertViewWillShow:(AMSmoothAlertView *)alertView;
+-(void) alertViewDidShow:(AMSmoothAlertView *)alertView;
+-(void) alertViewWillDismiss:(AMSmoothAlertView *)alertView;
+-(void) alertViewDidDismiss:(AMSmoothAlertView *)alertView;
 
 @end

--- a/AMSmoothAlertViewDemo/AMSmoothAlert/AMSmoothAlertView.h
+++ b/AMSmoothAlertViewDemo/AMSmoothAlert/AMSmoothAlertView.h
@@ -44,6 +44,7 @@
 
 @protocol AMSmoothAlertViewDelegate <NSObject>
 
+@optional
 -(void) alertView:(AMSmoothAlertView *)alertView didDismissWithButton:(UIButton *)button;
 -(void) alertViewWillShow;
 -(void) alertViewDidShow;

--- a/AMSmoothAlertViewDemo/AMSmoothAlert/AMSmoothAlertView.h
+++ b/AMSmoothAlertViewDemo/AMSmoothAlert/AMSmoothAlertView.h
@@ -3,6 +3,7 @@
 //  AMSmoothAlertViewDemo
 //
 //  Created by AMarliac on 2014-04-24.
+//  Contributor: Everest Liu
 //  Copyright (c) 2014 AMarliac. All rights reserved.
 //
 
@@ -43,6 +44,10 @@
 
 @protocol AMSmoothAlertViewDelegate <NSObject>
 
--(void)alertView:(AMSmoothAlertView *)alertView didDismissWithButton:(UIButton *)button;
+-(void) alertView:(AMSmoothAlertView *)alertView didDismissWithButton:(UIButton *)button;
+-(void) alertViewWillShow;
+-(void) alertViewDidShow;
+-(void) alertViewWillDismiss;
+-(void) alertViewDidDismiss;
 
 @end

--- a/AMSmoothAlertViewDemo/AMSmoothAlert/AMSmoothAlertView.m
+++ b/AMSmoothAlertViewDemo/AMSmoothAlert/AMSmoothAlertView.m
@@ -3,6 +3,7 @@
 //  AMSmoothAlertViewDemo
 //
 //  Created by AMarliac on 2014-04-24.
+//  Contributor: Everest Liu
 //  Copyright (c) 2014 AMarliac. All rights reserved.
 //
 
@@ -84,6 +85,9 @@
 
 - (void) show
 {
+	id<AMSmoothAlertViewDelegate> delegate = self.delegate;
+	if ([delegate respondsToSelector:@selector(alertViewWillShow)]) [delegate alertViewWillShow];
+
     switch (_animationType) {
         case DropAnimation:
             [self triggerDropAnimations];
@@ -383,6 +387,8 @@
     //add a block to our queue
     [animationBlocks addObject:^(BOOL finished){;
         self.isDisplayed = true;
+		id<AMSmoothAlertViewDelegate> delegate = self.delegate;
+		if ([delegate respondsToSelector:@selector(alertViewDidShow)]) [delegate alertViewDidShow];
     }];
     
     // execute the first block in the queue
@@ -392,6 +398,8 @@
 
 - (void) dismissAlertView
 {
+	id<AMSmoothAlertViewDelegate> delegate = self.delegate;
+	if ([delegate respondsToSelector:@selector(alertViewWillDismiss)]) [delegate alertViewWillDismiss];
     [UIView animateWithDuration:0.4
                           delay:0.0
                         options: UIViewAnimationOptionCurveEaseInOut
@@ -401,6 +409,7 @@
                      completion:^(BOOL finished){
                          [self removeFromSuperview];
                          self.isDisplayed = false;
+						 if ([delegate respondsToSelector:@selector(alertViewDidDismiss)]) [delegate alertViewDidDismiss];
                      }];
 }
 

--- a/AMSmoothAlertViewDemo/AMSmoothAlert/AMSmoothAlertView.m
+++ b/AMSmoothAlertViewDemo/AMSmoothAlert/AMSmoothAlertView.m
@@ -86,7 +86,7 @@
 - (void) show
 {
 	id<AMSmoothAlertViewDelegate> delegate = self.delegate;
-	if ([delegate respondsToSelector:@selector(alertViewWillShow)]) [delegate alertViewWillShow];
+	if ([delegate respondsToSelector:@selector(alertViewWillShow:)]) [delegate alertViewWillShow:self];
 
     switch (_animationType) {
         case DropAnimation:
@@ -388,7 +388,7 @@
     [animationBlocks addObject:^(BOOL finished){;
         self.isDisplayed = true;
 		id<AMSmoothAlertViewDelegate> delegate = self.delegate;
-		if ([delegate respondsToSelector:@selector(alertViewDidShow)]) [delegate alertViewDidShow];
+		if ([delegate respondsToSelector:@selector(alertViewDidShow:)]) [delegate alertViewDidShow:self];
     }];
     
     // execute the first block in the queue
@@ -399,7 +399,7 @@
 - (void) dismissAlertView
 {
 	id<AMSmoothAlertViewDelegate> delegate = self.delegate;
-	if ([delegate respondsToSelector:@selector(alertViewWillDismiss)]) [delegate alertViewWillDismiss];
+	if ([delegate respondsToSelector:@selector(alertViewWillDismiss:)]) [delegate alertViewWillDismiss:self];
     [UIView animateWithDuration:0.4
                           delay:0.0
                         options: UIViewAnimationOptionCurveEaseInOut
@@ -409,7 +409,7 @@
                      completion:^(BOOL finished){
                          [self removeFromSuperview];
                          self.isDisplayed = false;
-						 if ([delegate respondsToSelector:@selector(alertViewDidDismiss)]) [delegate alertViewDidDismiss];
+						 if ([delegate respondsToSelector:@selector(alertViewDidDismiss:)]) [delegate alertViewDidDismiss:self];
                      }];
 }
 

--- a/AMSmoothAlertViewDemo/AMViewController.m
+++ b/AMSmoothAlertViewDemo/AMViewController.m
@@ -51,6 +51,7 @@
 			case 3:
 				alert = [[AMSmoothAlertView alloc]initDropAlertWithTitle:@"Notice !" andText:@"This fires the delegate methods; Check your console!" andCancelButton:YES forAlertType:AlertInfo];
 				[alert setTitleFont:[UIFont fontWithName:@"Verdana" size:25.0f]];
+                alert.tag = 0;
 				alert.delegate = self;
 				break;
                 
@@ -80,20 +81,21 @@
 	}
 }
 
-- (void)alertViewWillShow {
-	NSLog(@"AlertView Will Show");
+- (void)alertViewWillShow:(AMSmoothAlertView *)alertView {
+    if (alertView.tag == 0)
+        NSLog(@"AlertView Will Show: '%@'", alertView.titleLabel.text);
 }
 
-- (void)alertViewDidShow {
-	NSLog(@"AlertView Did Show");
+- (void)alertViewDidShow:(AMSmoothAlertView *)alertView {
+	NSLog(@"AlertView Did Show: '%@'", alertView.titleLabel.text);
 }
 
-- (void)alertViewWillDismiss {
-	NSLog(@"AlertView Will Dismiss");
+- (void)alertViewWillDismiss:(AMSmoothAlertView *)alertView {
+	NSLog(@"AlertView Will Dismiss: '%@'", alertView.titleLabel.text);
 }
 
-- (void)alertViewDidDismiss {
-	NSLog(@"AlertView Did Dismiss");
+- (void)alertViewDidDismiss:(AMSmoothAlertView *)alertView {
+	NSLog(@"AlertView Did Dismiss: '%@'", alertView.titleLabel.text);
 }
 
 

--- a/AMSmoothAlertViewDemo/AMViewController.m
+++ b/AMSmoothAlertViewDemo/AMViewController.m
@@ -68,18 +68,32 @@
 
 }
 
-#pragma mark - Delegate
+#pragma mark - Delegates
 - (void)alertView:(AMSmoothAlertView *)alertView didDismissWithButton:(UIButton *)button {
 	if (alertView == alert) {
 		if (button == alert.defaultButton) {
 			NSLog(@"Default button touched!");
-			[alertView dismissAlertView];
 		}
 		if (button == alert.cancelButton) {
 			NSLog(@"Cancel button touched!");
-			[alertView dismissAlertView];
 		}
 	}
+}
+
+- (void)alertViewWillShow {
+	NSLog(@"AlertView Will Show");
+}
+
+- (void)alertViewDidShow {
+	NSLog(@"AlertView Did Show");
+}
+
+- (void)alertViewWillDismiss {
+	NSLog(@"AlertView Will Dismiss");
+}
+
+- (void)alertViewDidDismiss {
+	NSLog(@"AlertView Did Dismiss");
 }
 
 


### PR DESCRIPTION
...lDismiss, alertViewDidDismiss

Since the AMSmoothAlertView isn't a straight drop-in replacement of UIAlertView, these will come in handy, for example, when certain UI components need `component.enabled = NO`, especially if that component triggers an alert, because multiple alerts will just start stacking on top of each other.

Since the keyboard stays on top of the blurred image view, if I hit "Go" on the keyboard and that triggers an alert, I can inadvertently make a bunch of AMSmoothAlertViews start appearing and make an ugly stack of them.
