### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ AMSmoothAlert
 ==================
 • Now include multiple buttons feature you asked :)
 
-• Now available on Cocoapods : AMSmoothAlert
+• Now available on CocoaPods : AMSmoothAlert
 
 
 I saw this pretty cool alert view concept on [Dribbble](https://dribbble.com/shots/1523277-Success-Popup-for-Handybook-New-App-GIF?list=users&offset=0) so i decided to reproduce it !
@@ -11,7 +11,7 @@ I saw this pretty cool alert view concept on [Dribbble](https://dribbble.com/sho
 
 (the above gif is slower than the real speed animation)
 
-##Installation Cocoapods
+##Installation CocoaPods
 
 Add this in your Podfile
 ```


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
